### PR TITLE
Add more translation diagnostics

### DIFF
--- a/intel4004_emu/translator.py
+++ b/intel4004_emu/translator.py
@@ -95,6 +95,8 @@ class Line(object):
             raise Exception("Unknown instruction %s %s" % (self.opcode, inTheLine))
         if len(self.parts) != params + 1:
             raise Exception("Expected %d parameters %s" % (params, inTheLine))
+        if self.opcode=='ld' and not (type(self.params[0]) is str) :
+            raise Exception("Expected register parameter for ld instruction  %s" % ( inTheLine))
         self.size = size
         self.addr = addr
     


### PR DESCRIPTION
Prevent from silently accepting commands like "ld 14",  where user mistyped from "ldm 14"